### PR TITLE
Fix #1: Add menuItems field to Restaurant GraphQL entity

### DIFF
--- a/backend/src/restaurant/entities/restaurant.entity.ts
+++ b/backend/src/restaurant/entities/restaurant.entity.ts
@@ -2,6 +2,7 @@
 
 import { ObjectType, Field, ID } from '@nestjs/graphql';
 import { Country } from '@prisma/client';
+import { MenuItem } from '../../menu/entities/menu-item.entity';
 
 @ObjectType()
 export class Restaurant {
@@ -14,4 +15,8 @@ export class Restaurant {
 
   @Field()
   country: Country;
+
+  // Add this field
+  @Field(() => [MenuItem], { nullable: true })
+  menuItems?: MenuItem[];
 }

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -2,17 +2,18 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
-type Restaurant {
-  id: ID!
-  name: String!
-  country: String!
-}
-
 type MenuItem {
   id: ID!
   name: String!
   price: Float!
   restaurantId: String!
+}
+
+type Restaurant {
+  id: ID!
+  name: String!
+  country: String!
+  menuItems: [MenuItem!]
 }
 
 type Order {


### PR DESCRIPTION
Fix: #1  
<img width="963" height="574" alt="image" src="https://github.com/user-attachments/assets/22cf6cf7-a7fa-421e-911e-c3056859c40c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restaurants can now display associated menu items, including pricing and item details in their profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->